### PR TITLE
Set check alias to :check in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The deps.edn file contains a basic setup and some common aliases:
    :test {:extra-paths ["test"]}
 
    ;; test.check 
-   :test {:extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}}}
+   :check {:extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}}}
 
    ;; benchmarking
    :bench {:extra-deps {criterium {:mvn/version "0.4.4"}}}}


### PR DESCRIPTION
Hello!

There was a duplicate `:test` key in README. Checking the source `deps.edn`, there wasn't. Is this what you meant?

Regards,
Teodor